### PR TITLE
Implement movies list and detail endpoints

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,1 +1,1 @@
-from config.settings import get_settings
+from src.config.settings import get_settings

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -1,8 +1,8 @@
-from database.models import (
+from src.database.models import (
     Base,
     MovieModel
 )
-from database.session import (
+from src.database.session import (
     init_db,
     close_db,
     get_db_contextmanager,

--- a/src/database/populate.py
+++ b/src/database/populate.py
@@ -4,8 +4,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import SQLAlchemyError
 from tqdm.asyncio import tqdm
 
-from config import get_settings
-from database import MovieModel, get_db_contextmanager, init_db
+from src.config import get_settings
+from src.database import MovieModel, get_db_contextmanager, init_db
 
 
 class CSVDatabaseSeeder:

--- a/src/database/session.py
+++ b/src/database/session.py
@@ -4,8 +4,8 @@ from typing import AsyncGenerator
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 
-from config import get_settings
-from database import Base
+from src.config import get_settings
+from src.database import Base
 
 settings = get_settings()
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from database import init_db, close_db
-from routes import movie_router
+from src.database import init_db, close_db
+from src.routes import movie_router
 
 
 @asynccontextmanager

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,1 +1,1 @@
-from routes.movies import router as movie_router
+from src.routes.movies import router as movie_router

--- a/src/routes/movies.py
+++ b/src/routes/movies.py
@@ -1,10 +1,51 @@
+import math
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from database import get_db, MovieModel
-
+from src.database import get_db, MovieModel
+from src.schemas import MovieListResponseSchema, MovieDetailResponseSchema
 
 router = APIRouter()
+movie_router = router
 
-# Write your code here
+
+@router.get("/movies/", response_model=MovieListResponseSchema)
+async def get_movies(
+        page: int = Query(1, ge=1),
+        per_page: int = Query(ge=1, le=20, default=10),
+        db: AsyncSession = Depends(get_db),
+):
+    count_stmt = select(func.count()).select_from(MovieModel)
+    result = await db.execute(count_stmt)
+    total_items = result.scalar()
+
+    total_pages = math.ceil(total_items / per_page)
+    offset = (page - 1) * per_page
+
+    stmt = select(MovieModel).offset(offset).limit(per_page)
+    result = await db.execute(stmt)
+    movies = result.scalars().all()
+
+    if not movies:
+        raise HTTPException(status_code=404, detail="No movies found.")
+
+    prev_page = f"/theater/movies/?page={max(1, page - 1)}&per_page={per_page}" if page > 1 else None
+    next_page = (f"/theater/movies/?page={min(total_pages, page + 1)}"
+                 f"&per_page={per_page}") if page < total_pages else None
+
+    return {
+        "movies": movies,
+        "prev_page": prev_page,
+        "next_page": next_page,
+        "total_pages": total_pages,
+        "total_items": total_items,
+    }
+
+
+@router.get("/movies/{movie_id}", response_model=MovieDetailResponseSchema)
+async def get_movie(movie_id: int, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(MovieModel).where(MovieModel.id == movie_id))
+    movie = result.scalar_one_or_none()
+    if not movie:
+        raise HTTPException(status_code=404, detail="Movie with id {movie_id} not found")
+    return movie

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,4 +1,4 @@
-from schemas.movies import (
+from src.schemas.movies import (
     MovieDetailResponseSchema,
     MovieListResponseSchema
 )

--- a/src/schemas/movies.py
+++ b/src/schemas/movies.py
@@ -1,1 +1,26 @@
-# Write your code here
+from typing import List, Optional
+
+from pydantic import BaseModel
+from datetime import date
+
+class MovieDetailResponseSchema(BaseModel):
+    id: int
+    name: str
+    date: date
+    score: float
+    genre: str
+    overview: str
+    crew: str
+    orig_title: str
+    status: str
+    orig_lang: str
+    budget: float
+    revenue: float
+    country: str
+
+class MovieListResponseSchema(BaseModel):
+    movies: List[MovieDetailResponseSchema]
+    prev_page: Optional[str] = None
+    next_page: Optional[str] = None
+    total_pages: int
+    total_items: int

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,13 +1,13 @@
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
-from config import get_settings
-from database import (
+from src.config import get_settings
+from src.database import (
     reset_sqlite_database,
     get_db_contextmanager,
 )
-from database.populate import CSVDatabaseSeeder
-from main import app
+from src.database.populate import CSVDatabaseSeeder
+from src.main import app
 
 
 @pytest_asyncio.fixture(scope="function", autouse=True)

--- a/src/tests/test_integration/test_movies.py
+++ b/src/tests/test_integration/test_movies.py
@@ -2,7 +2,7 @@ import random
 import pytest
 from sqlalchemy import select, func
 
-from database import MovieModel
+from src.database import MovieModel
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What was done:
- Implemented GET /movies/ endpoint with pagination
- Implemented GET /movies/{movie_id} endpoint
- Added Pydantic schemas for responses
- Added pagination metadata: total_pages, total_items, prev_page, next_page
- Returned 404 error if no movies found or invalid movie ID

### Note:
- All endpoints are under the prefix /api/v1/theater/
- Used async SQLAlchemy queries with AsyncSession